### PR TITLE
Fix master vs main in GHA workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,5 +33,5 @@ jobs:
       - name: "Test if publishing works"
         run: GRADLE_USER_HOME=$HOME/.gradle ./gradlew publishToMavenLocal --console=plain --no-daemon --stacktrace
       - name: "Tag release"
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: GRADLE_USER_HOME=$HOME/.gradle ./gradlew tagRelease --console=plain --no-daemon


### PR DESCRIPTION
## Context

The workflow was copied from an example that used master as the default branch, but this repo uses main. I failed to update the condition for the tagging build step.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
