### PR TITLE
Include contrib envoy-api files

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.29.0
+version=1.29.0-2
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8

--- a/src/main/proto/contrib/envoy/extensions/compression/qatzip/compressor/v3alpha/qatzip.proto
+++ b/src/main/proto/contrib/envoy/extensions/compression/qatzip/compressor/v3alpha/qatzip.proto
@@ -1,0 +1,52 @@
+syntax = "proto3";
+
+package envoy.extensions.compression.qatzip.compressor.v3alpha;
+
+import "google/protobuf/wrappers.proto";
+
+import "udpa/annotations/status.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.compression.qatzip.compressor.v3alpha";
+option java_outer_classname = "QatzipProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/compression/qatzip/compressor/v3alpha";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: Qatzip Compressor]
+// Qatzip :ref:`configuration overview <config_qatzip>`.
+// [#extension: envoy.compression.qatzip.compressor]
+
+// [#next-free-field: 6]
+message Qatzip {
+  enum HardwareBufferSize {
+    DEFAULT = 0;
+    SZ_4K = 1;
+    SZ_8K = 2;
+    SZ_32K = 3;
+    SZ_64K = 4;
+    SZ_128K = 5;
+    SZ_512K = 6;
+  }
+
+  // Value from 1 to 9 that controls the main compression speed-density lever.
+  // The higher quality, the slower compression. The default value is 1.
+  google.protobuf.UInt32Value compression_level = 1 [(validate.rules).uint32 = {lte: 9 gte: 1}];
+
+  // A size of qat hardware buffer. This field will be set to "DEFAULT" if not specified.
+  HardwareBufferSize hardware_buffer_size = 2 [(validate.rules).enum = {defined_only: true}];
+
+  // Threshold of compression service’s input size for software failover.
+  // If the size of input request less than the threshold, qatzip will route the request to software
+  // compressor. The default value is 1024. The maximum value is 512*1024.
+  google.protobuf.UInt32Value input_size_threshold = 3
+      [(validate.rules).uint32 = {lte: 524288 gte: 128}];
+
+  // A size of stream buffer. The default value is 128 * 1024. The maximum value is 2*1024*1024 -
+  // 5*1024
+  google.protobuf.UInt32Value stream_buffer_size = 4
+      [(validate.rules).uint32 = {lte: 2092032 gte: 1024}];
+
+  // Value for compressor's next output buffer. If not set, defaults to 4096.
+  google.protobuf.UInt32Value chunk_size = 5 [(validate.rules).uint32 = {lte: 65536 gte: 4096}];
+}

--- a/src/main/proto/contrib/envoy/extensions/config/v3alpha/kv_store_xds_delegate_config.proto
+++ b/src/main/proto/contrib/envoy/extensions/config/v3alpha/kv_store_xds_delegate_config.proto
@@ -1,0 +1,29 @@
+syntax = "proto3";
+
+package envoy.extensions.config.v3alpha;
+
+import "envoy/config/common/key_value/v3/config.proto";
+
+import "udpa/annotations/status.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.config.v3alpha";
+option java_outer_classname = "KvStoreXdsDelegateConfigProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/config/v3alpha";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#extension: envoy.xds_delegates.kv_store]
+//
+// Configuration for a KeyValueStore-based XdsResourcesDelegate implementation. This implementation
+// updates the underlying KV store with xDS resources received from the configured management
+// servers, enabling configuration to be persisted locally and used on startup in case connectivity
+// with the xDS management servers could not be established.
+//
+// The KV Store based delegate's handling of wildcard resources (empty resource list or "*") is
+// designed for use with O(100) resources or fewer, so it's not currently advised to use this
+// feature for large configurations with heavy use of wildcard resources.
+message KeyValueStoreXdsDelegateConfig {
+  // Configuration for the KeyValueStore that holds the xDS resources.
+  // [#allow-fully-qualified-name:]
+  .envoy.config.common.key_value.v3.KeyValueStoreConfig key_value_store_config = 1;
+}

--- a/src/main/proto/contrib/envoy/extensions/filters/http/checksum/v3alpha/checksum.proto
+++ b/src/main/proto/contrib/envoy/extensions/filters/http/checksum/v3alpha/checksum.proto
@@ -1,0 +1,48 @@
+syntax = "proto3";
+
+package envoy.extensions.filters.http.checksum.v3alpha;
+
+import "envoy/type/matcher/v3/string.proto";
+
+import "xds/annotations/v3/status.proto";
+
+import "udpa/annotations/status.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.filters.http.checksum.v3alpha";
+option java_outer_classname = "ChecksumProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/http/checksum/v3alpha";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+option (xds.annotations.v3.file_status).work_in_progress = true;
+
+// [#protodoc-title: Checksum HTTP filter]
+//
+// Filter to reject responses that don't match a specified checksum.
+// To avoid holding the entire response in memory, the rejection occurs at the end of the stream.
+// [#extension: envoy.filters.http.checksum]
+
+message ChecksumConfig {
+  message Checksum {
+    oneof matcher {
+      // A matcher for a path that is expected to have a specific checksum, as specified
+      // in the ``sha256`` field.
+      type.matcher.v3.StringMatcher path_matcher = 1 [(validate.rules).message = {required: true}];
+    }
+
+    // A hex-encoded sha256 string required to match the sha256sum of the response body
+    // of the path specified in the ``path_matcher`` field.
+    string sha256 = 2 [(validate.rules).string = {pattern: "^[a-fA-F0-9]{64}"}];
+  }
+
+  // A set of matcher and checksum pairs for which, if a path matching ``path_matcher``
+  // is requested and the checksum of the response body does not match the ``sha256``, the
+  // response will be replaced with a 403 Forbidden status.
+  //
+  // If multiple matchers match the same path, the first to match takes precedence.
+  repeated Checksum checksums = 1;
+
+  // If a request doesn't match any of the specified checksum paths and reject_unmatched is
+  // true, the request is rejected immediately with 403 Forbidden.
+  bool reject_unmatched = 2;
+}

--- a/src/main/proto/contrib/envoy/extensions/filters/http/dynamo/v3/dynamo.proto
+++ b/src/main/proto/contrib/envoy/extensions/filters/http/dynamo/v3/dynamo.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+
+package envoy.extensions.filters.http.dynamo.v3;
+
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.filters.http.dynamo.v3";
+option java_outer_classname = "DynamoProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/http/dynamo/v3;dynamov3";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: Dynamo]
+// Dynamo :ref:`configuration overview <config_http_filters_dynamo>`.
+// [#extension: envoy.filters.http.dynamo]
+
+// Dynamo filter config.
+message Dynamo {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.config.filter.http.dynamo.v2.Dynamo";
+}

--- a/src/main/proto/contrib/envoy/extensions/filters/http/golang/v3alpha/golang.proto
+++ b/src/main/proto/contrib/envoy/extensions/filters/http/golang/v3alpha/golang.proto
@@ -1,0 +1,99 @@
+syntax = "proto3";
+
+package envoy.extensions.filters.http.golang.v3alpha;
+
+import "google/protobuf/any.proto";
+
+import "xds/annotations/v3/status.proto";
+
+import "udpa/annotations/status.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.filters.http.golang.v3alpha";
+option java_outer_classname = "GolangProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/http/golang/v3alpha";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+option (xds.annotations.v3.file_status).work_in_progress = true;
+
+// [#protodoc-title: Golang HTTP filter]
+//
+// For an overview of the Golang HTTP filter please see the :ref:`configuration reference documentation <config_http_filters_golang>`.
+// [#extension: envoy.filters.http.golang]
+
+// [#next-free-field: 6]
+message Config {
+  // The meanings are as follows:
+  //
+  // :``MERGE_VIRTUALHOST_ROUTER_FILTER``: Pass all configuration into Go plugin.
+  // :``MERGE_VIRTUALHOST_ROUTER``: Pass merged Virtual host and Router configuration into Go plugin.
+  // :``OVERRIDE``: Pass merged Virtual host, Router, and plugin configuration into Go plugin.
+  //
+  // [#not-implemented-hide:]
+  enum MergePolicy {
+    MERGE_VIRTUALHOST_ROUTER_FILTER = 0;
+    MERGE_VIRTUALHOST_ROUTER = 1;
+    OVERRIDE = 3;
+  }
+
+  // Globally unique ID for a dynamic library file.
+  string library_id = 1 [(validate.rules).string = {min_len: 1}];
+
+  // Path to a dynamic library implementing the
+  // :repo:`StreamFilter API <contrib/golang/common/go/api.StreamFilter>`
+  // interface.
+  // [#comment:TODO(wangfakang): Support for downloading libraries from remote repositories.]
+  string library_path = 2 [(validate.rules).string = {min_len: 1}];
+
+  // Globally unique name of the Go plugin.
+  //
+  // This name **must** be consistent with the name registered in ``http::RegisterHttpFilterConfigFactory``,
+  // and can be used to associate :ref:`route and virtualHost plugin configuration
+  // <envoy_v3_api_field_extensions.filters.http.golang.v3alpha.ConfigsPerRoute.plugins_config>`.
+  //
+  string plugin_name = 3 [(validate.rules).string = {min_len: 1}];
+
+  // Configuration for the Go plugin.
+  //
+  // .. note::
+  //     This configuration is only parsed in the go plugin, and is therefore not validated
+  //     by Envoy.
+  //
+  //     See the :repo:`StreamFilter API <contrib/golang/common/go/api/filter.go>`
+  //     for more information about how the plugin's configuration data can be accessed.
+  //
+  google.protobuf.Any plugin_config = 4;
+
+  // Merge policy for plugin configuration.
+  //
+  // The Go plugin configuration supports three dimensions:
+  //
+  // * Virtual host’s :ref:`typed_per_filter_config <envoy_v3_api_field_config.route.v3.VirtualHost.typed_per_filter_config>`
+  // * Route’s :ref:`typed_per_filter_config <envoy_v3_api_field_config.route.v3.Route.typed_per_filter_config>`
+  // * The filter's :ref:`plugin_config <envoy_v3_api_field_extensions.filters.http.golang.v3alpha.Config.plugin_config>`
+  //
+  // [#not-implemented-hide:]
+  MergePolicy merge_policy = 5 [(validate.rules).enum = {defined_only: true}];
+}
+
+message RouterPlugin {
+  oneof override {
+    option (validate.required) = true;
+
+    // [#not-implemented-hide:]
+    // Disable the filter for this particular vhost or route.
+    // If disabled is specified in multiple per-filter-configs, the most specific one will be used.
+    bool disabled = 1 [(validate.rules).bool = {const: true}];
+
+    // The config field is used for setting per-route and per-virtualhost plugin config.
+    google.protobuf.Any config = 2;
+  }
+}
+
+message ConfigsPerRoute {
+  // Configuration of the Go plugin at the per-router or per-virtualhost level,
+  // keyed on the :ref:`plugin_name <envoy_v3_api_field_extensions.filters.http.golang.v3alpha.Config.plugin_name>`
+  // of the Go plugin.
+  //
+  map<string, RouterPlugin> plugins_config = 1;
+}

--- a/src/main/proto/contrib/envoy/extensions/filters/http/language/v3alpha/language.proto
+++ b/src/main/proto/contrib/envoy/extensions/filters/http/language/v3alpha/language.proto
@@ -1,0 +1,41 @@
+syntax = "proto3";
+
+package envoy.extensions.filters.http.language.v3alpha;
+
+import "udpa/annotations/status.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.filters.http.language.v3alpha";
+option java_outer_classname = "LanguageProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/http/language/v3alpha";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: Language]
+// Language :ref:`configuration overview <config_http_filters_language>`.
+// [#extension: envoy.filters.http.language]
+
+// Language detection filter config.
+message Language {
+  // The default language to be used as a fallback.
+  // The value will be included in the list of the supported languages.
+  //
+  // See https://unicode-org.github.io/icu/userguide/locale/
+  string default_language = 1 [(validate.rules).string = {min_len: 2}];
+
+  // The set of supported languages. There is no order priority.
+  // The order will be determined by the Accept-Language header priority list
+  // of the client.
+  //
+  // See https://unicode-org.github.io/icu/userguide/locale/
+  repeated string supported_languages = 2 [(validate.rules).repeated = {
+    min_items: 1
+    unique: true
+    items {string {min_len: 2}}
+  }];
+
+  // If the x-language header is altered, clear the route cache for the current request.
+  // This should be set if the route configuration may depend on the x-language header.
+  // Otherwise it should be unset to avoid the performance cost of route recalculation.
+  bool clear_route_cache = 3;
+}

--- a/src/main/proto/contrib/envoy/extensions/filters/http/squash/v3/squash.proto
+++ b/src/main/proto/contrib/envoy/extensions/filters/http/squash/v3/squash.proto
@@ -1,0 +1,61 @@
+syntax = "proto3";
+
+package envoy.extensions.filters.http.squash.v3;
+
+import "google/protobuf/duration.proto";
+import "google/protobuf/struct.proto";
+
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.filters.http.squash.v3";
+option java_outer_classname = "SquashProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/http/squash/v3;squashv3";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: Squash]
+// Squash :ref:`configuration overview <config_http_filters_squash>`.
+// [#extension: envoy.filters.http.squash]
+
+// [#next-free-field: 6]
+message Squash {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.config.filter.http.squash.v2.Squash";
+
+  // The name of the cluster that hosts the Squash server.
+  string cluster = 1 [(validate.rules).string = {min_len: 1}];
+
+  // When the filter requests the Squash server to create a DebugAttachment, it will use this
+  // structure as template for the body of the request. It can contain reference to environment
+  // variables in the form of '{{ ENV_VAR_NAME }}'. These can be used to provide the Squash server
+  // with more information to find the process to attach the debugger to. For example, in a
+  // Istio/k8s environment, this will contain information on the pod:
+  //
+  // .. code-block:: json
+  //
+  //  {
+  //    "spec": {
+  //      "attachment": {
+  //        "pod": "{{ POD_NAME }}",
+  //        "namespace": "{{ POD_NAMESPACE }}"
+  //      },
+  //      "match_request": true
+  //    }
+  //  }
+  //
+  // (where POD_NAME, POD_NAMESPACE are configured in the pod via the Downward API)
+  google.protobuf.Struct attachment_template = 2;
+
+  // The timeout for individual requests sent to the Squash cluster. Defaults to 1 second.
+  google.protobuf.Duration request_timeout = 3;
+
+  // The total timeout Squash will delay a request and wait for it to be attached. Defaults to 60
+  // seconds.
+  google.protobuf.Duration attachment_timeout = 4;
+
+  // Amount of time to poll for the status of the attachment object in the Squash server
+  // (to check if has been attached). Defaults to 1 second.
+  google.protobuf.Duration attachment_poll_period = 5;
+}

--- a/src/main/proto/contrib/envoy/extensions/filters/http/sxg/v3alpha/sxg.proto
+++ b/src/main/proto/contrib/envoy/extensions/filters/http/sxg/v3alpha/sxg.proto
@@ -1,0 +1,68 @@
+syntax = "proto3";
+
+package envoy.extensions.filters.http.sxg.v3alpha;
+
+import "envoy/extensions/transport_sockets/tls/v3/secret.proto";
+
+import "google/protobuf/duration.proto";
+
+import "udpa/annotations/status.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.filters.http.sxg.v3alpha";
+option java_outer_classname = "SxgProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/http/sxg/v3alpha";
+option (udpa.annotations.file_status).work_in_progress = true;
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: Signed HTTP Exchange Filter]
+// SXG :ref:`configuration overview <config_http_filters_sxg>`.
+// [#extension: envoy.filters.http.sxg]
+
+// [#next-free-field: 10]
+message SXG {
+  // The SDS configuration for the public key data for the SSL certificate that will be used to sign the
+  // SXG response.
+  transport_sockets.tls.v3.SdsSecretConfig certificate = 1;
+
+  // The SDS configuration for the private key data for the SSL certificate that will be used to sign the
+  // SXG response.
+  transport_sockets.tls.v3.SdsSecretConfig private_key = 2;
+
+  // The duration for which the generated SXG package will be valid. Default is 604800s (7 days in seconds).
+  // Note that in order to account for clock skew, the timestamp will be backdated by a day. So, if duration
+  // is set to 7 days, that will be 7 days from 24 hours ago (6 days from now). Also note that while 6/7 days
+  // is appropriate for most content, if the downstream service is serving Javascript, or HTML with inline
+  // Javascript, 1 day (so, with backdated expiry, 2 days, or 172800 seconds) is more appropriate.
+  google.protobuf.Duration duration = 3;
+
+  // The SXG response payload is Merkle Integrity Content Encoding (MICE) encoded (specification is [here](https://datatracker.ietf.org/doc/html/draft-thomson-http-mice-03))
+  // This value indicates the record size in the encoded payload. The default value is 4096.
+  uint64 mi_record_size = 4;
+
+  // The URI of certificate CBOR file published. Since it is required that the certificate CBOR file
+  // be served from the same domain as the SXG document, this should be a relative URI.
+  string cbor_url = 5 [(validate.rules).string = {min_len: 1 prefix: "/"}];
+
+  // URL to retrieve validity data for signature, a CBOR map. See specification [here](https://tools.ietf.org/html/draft-yasskin-httpbis-origin-signed-exchanges-impl-00#section-3.6)
+  string validity_url = 6 [(validate.rules).string = {min_len: 1 prefix: "/"}];
+
+  // Header that will be set if it is determined that the client can accept SXG (typically ``accept: application/signed-exchange;v=b3``)
+  // If not set, filter will default to: ``x-client-can-accept-sxg``
+  string client_can_accept_sxg_header = 7 [
+    (validate.rules).string = {well_known_regex: HTTP_HEADER_NAME strict: false ignore_empty: true}
+  ];
+
+  // Header set by downstream service to signal that the response should be transformed to SXG If not set,
+  // filter will default to: ``x-should-encode-sxg``
+  string should_encode_sxg_header = 8 [
+    (validate.rules).string = {well_known_regex: HTTP_HEADER_NAME strict: false ignore_empty: true}
+  ];
+
+  // Headers that will be stripped from the SXG document, by listing a prefix (i.e. ``x-custom-`` will cause
+  // all headers prefixed by ``x-custom-`` to be omitted from the SXG document)
+  repeated string header_prefix_filters = 9 [
+    (validate.rules).repeated = {items {string {well_known_regex: HTTP_HEADER_NAME strict: false}}}
+  ];
+}

--- a/src/main/proto/contrib/envoy/extensions/filters/network/client_ssl_auth/v3/client_ssl_auth.proto
+++ b/src/main/proto/contrib/envoy/extensions/filters/network/client_ssl_auth/v3/client_ssl_auth.proto
@@ -1,0 +1,51 @@
+syntax = "proto3";
+
+package envoy.extensions.filters.network.client_ssl_auth.v3;
+
+import "envoy/config/core/v3/address.proto";
+
+import "google/protobuf/duration.proto";
+
+import "udpa/annotations/migrate.proto";
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.filters.network.client_ssl_auth.v3";
+option java_outer_classname = "ClientSslAuthProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/network/client_ssl_auth/v3;client_ssl_authv3";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: Client TLS authentication]
+// Client TLS authentication
+// :ref:`configuration overview <config_network_filters_client_ssl_auth>`.
+// [#extension: envoy.filters.network.client_ssl_auth]
+
+message ClientSSLAuth {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.config.filter.network.client_ssl_auth.v2.ClientSSLAuth";
+
+  // The :ref:`cluster manager <arch_overview_cluster_manager>` cluster that runs
+  // the authentication service. The filter will connect to the service every 60s to fetch the list
+  // of principals. The service must support the expected :ref:`REST API
+  // <config_network_filters_client_ssl_auth_rest_api>`.
+  string auth_api_cluster = 1
+      [(validate.rules).string = {min_len: 1 well_known_regex: HTTP_HEADER_VALUE strict: false}];
+
+  // The prefix to use when emitting :ref:`statistics
+  // <config_network_filters_client_ssl_auth_stats>`.
+  string stat_prefix = 2 [(validate.rules).string = {min_len: 1}];
+
+  // Time in milliseconds between principal refreshes from the
+  // authentication service. Default is 60000 (60s). The actual fetch time
+  // will be this value plus a random jittered value between
+  // 0-refresh_delay_ms milliseconds.
+  google.protobuf.Duration refresh_delay = 3;
+
+  // An optional list of IP address and subnet masks that should be white
+  // listed for access by the filter. If no list is provided, there is no
+  // IP allowlist.
+  repeated config.core.v3.CidrRange ip_white_list = 4
+      [(udpa.annotations.field_migrate).rename = "ip_allowlist"];
+}

--- a/src/main/proto/contrib/envoy/extensions/filters/network/generic_proxy/action/v3/action.proto
+++ b/src/main/proto/contrib/envoy/extensions/filters/network/generic_proxy/action/v3/action.proto
@@ -1,0 +1,50 @@
+syntax = "proto3";
+
+package envoy.extensions.filters.network.generic_proxy.action.v3;
+
+import "envoy/config/core/v3/base.proto";
+import "envoy/config/route/v3/route_components.proto";
+
+import "google/protobuf/any.proto";
+
+import "xds/annotations/v3/status.proto";
+
+import "udpa/annotations/status.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.filters.network.generic_proxy.action.v3";
+option java_outer_classname = "ActionProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/network/generic_proxy/action/v3;actionv3";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+option (xds.annotations.v3.file_status).work_in_progress = true;
+
+// [#protodoc-title: Generic Proxy Route Action Configuration]
+
+// Configuration for the route match action.
+// [#next-free-field: 6]
+message RouteAction {
+  // The name of the route action. This should be unique across all route actions.
+  string name = 5;
+
+  oneof cluster_specifier {
+    option (validate.required) = true;
+
+    // Indicates the upstream cluster to which the request should be routed.
+    string cluster = 1;
+
+    // [#not-implemented-hide:]
+    // Multiple upstream clusters can be specified for a given route. The request is routed to one
+    // of the upstream clusters based on weights assigned to each cluster.
+    // Currently ClusterWeight only supports the name and weight fields.
+    config.route.v3.WeightedCluster weighted_clusters = 2;
+  }
+
+  // Route metadata.
+  config.core.v3.Metadata metadata = 3;
+
+  // Route level config for L7 generic filters. The key should be the related :ref:`extension name
+  // <envoy_v3_api_field_config.core.v3.TypedExtensionConfig.name>` in the :ref:`generic filters
+  // <envoy_v3_api_field_extensions.filters.network.generic_proxy.v3.GenericProxy.filters>`.
+  map<string, google.protobuf.Any> per_filter_config = 4;
+}

--- a/src/main/proto/contrib/envoy/extensions/filters/network/generic_proxy/codecs/dubbo/v3/dubbo.proto
+++ b/src/main/proto/contrib/envoy/extensions/filters/network/generic_proxy/codecs/dubbo/v3/dubbo.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+package envoy.extensions.filters.network.generic_proxy.codecs.dubbo.v3;
+
+import "xds/annotations/v3/status.proto";
+
+import "udpa/annotations/status.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.filters.network.generic_proxy.codecs.dubbo.v3";
+option java_outer_classname = "DubboProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/network/generic_proxy/codecs/dubbo/v3;dubbov3";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+option (xds.annotations.v3.file_status).work_in_progress = true;
+
+// [#protodoc-title: Dubbo codec configuration for Generic Proxy]
+// [#extension: envoy.generic_proxy.codecs.dubbo]
+
+message DubboCodecConfig {
+}

--- a/src/main/proto/contrib/envoy/extensions/filters/network/generic_proxy/codecs/kafka/v3/kafka.proto
+++ b/src/main/proto/contrib/envoy/extensions/filters/network/generic_proxy/codecs/kafka/v3/kafka.proto
@@ -1,0 +1,35 @@
+syntax = "proto3";
+
+package envoy.extensions.filters.network.generic_proxy.codecs.kafka.v3;
+
+import "xds/annotations/v3/status.proto";
+
+import "udpa/annotations/status.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.filters.network.generic_proxy.codecs.kafka.v3";
+option java_outer_classname = "KafkaProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/network/generic_proxy/codecs/kafka/v3;kafkav3";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+option (xds.annotations.v3.file_status).work_in_progress = true;
+
+// [#protodoc-title: Kafka codec configuration for Generic Proxy]
+// [#extension: envoy.generic_proxy.codecs.kafka]
+
+// Configuration for Kafka codec. This codec gives the generic proxy the ability to proxy
+// Kafka traffic. But note any route configuration for Kafka traffic is not supported yet.
+// The generic proxy can only used to generate logs or metrics for Kafka traffic but cannot
+// do matching or routing.
+//
+// .. note::
+//   The codec can currently only be used in the sidecar mode. And to ensure the codec works
+//   properly, please make sure the following conditions are met:
+//
+//   1. The generic proxy must be configured with a wildcard route that matches all traffic.
+//   2. The target cluster must be configured as a original destination cluster.
+//   3. The :ref:`bind_upstream_connection
+//      <envoy_v3_api_field_extensions.filters.network.generic_proxy.router.v3.Router.bind_upstream_connection>`
+//      of generic proxy router must be set to true to ensure same upstream connection is used
+//      for all traffic from same downstream connection.
+message KafkaCodecConfig {
+}

--- a/src/main/proto/contrib/envoy/extensions/filters/network/generic_proxy/matcher/v3/matcher.proto
+++ b/src/main/proto/contrib/envoy/extensions/filters/network/generic_proxy/matcher/v3/matcher.proto
@@ -1,0 +1,80 @@
+syntax = "proto3";
+
+package envoy.extensions.filters.network.generic_proxy.matcher.v3;
+
+import "envoy/type/matcher/v3/string.proto";
+
+import "xds/annotations/v3/status.proto";
+
+import "udpa/annotations/status.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.filters.network.generic_proxy.matcher.v3";
+option java_outer_classname = "MatcherProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/network/generic_proxy/matcher/v3;matcherv3";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+option (xds.annotations.v3.file_status).work_in_progress = true;
+
+// [#protodoc-title: Generic Proxy Route Matcher Configuration]
+
+// Used to match request service of the downstream request. Only applicable if a service provided
+// by the application protocol.
+// This is deprecated and should be replaced by HostMatchInput. This is kept for backward compatibility.
+message ServiceMatchInput {
+}
+
+// Used to match request host of the generic downstream request. Only applicable if a host provided
+// by the application protocol.
+// This is same with the ServiceMatchInput and this should be preferred over ServiceMatchInput.
+message HostMatchInput {
+}
+
+// Used to match request path of the generic downstream request. Only applicable if a path provided
+// by the application protocol.
+message PathMatchInput {
+}
+
+// Used to match request method of the generic downstream request. Only applicable if a method provided
+// by the application protocol.
+message MethodMatchInput {
+}
+
+// Used to match an arbitrary property of the generic downstream request.
+// These properties are populated by the codecs of application protocols.
+message PropertyMatchInput {
+  // The property name to match on.
+  string property_name = 1 [(validate.rules).string = {min_len: 1}];
+}
+
+// Used to match an whole generic downstream request.
+message RequestMatchInput {
+}
+
+// Used to match an arbitrary key-value pair for headers, trailers or properties.
+message KeyValueMatchEntry {
+  // The key name to match on.
+  string name = 1 [(validate.rules).string = {min_len: 1}];
+
+  // The key value pattern.
+  type.matcher.v3.StringMatcher string_match = 2 [(validate.rules).message = {required: true}];
+}
+
+// Custom matcher to match on the generic downstream request. This is used to match
+// multiple fields of the downstream request and avoid complex combinations of
+// HostMatchInput, PathMatchInput, MethodMatchInput and PropertyMatchInput.
+message RequestMatcher {
+  // Optional host pattern to match on. If not specified, any host will match.
+  type.matcher.v3.StringMatcher host = 1;
+
+  // Optional path pattern to match on. If not specified, any path will match.
+  type.matcher.v3.StringMatcher path = 2;
+
+  // Optional method pattern to match on. If not specified, any method will match.
+  type.matcher.v3.StringMatcher method = 3;
+
+  // Optional arbitrary properties to match on. If not specified, any properties
+  // will match. The key is the property name and the value is the property value
+  // to match on.
+  repeated KeyValueMatchEntry properties = 4;
+}

--- a/src/main/proto/contrib/envoy/extensions/filters/network/generic_proxy/router/v3/router.proto
+++ b/src/main/proto/contrib/envoy/extensions/filters/network/generic_proxy/router/v3/router.proto
@@ -1,0 +1,43 @@
+syntax = "proto3";
+
+package envoy.extensions.filters.network.generic_proxy.router.v3;
+
+import "xds/annotations/v3/status.proto";
+
+import "udpa/annotations/status.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.filters.network.generic_proxy.router.v3";
+option java_outer_classname = "RouterProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/network/generic_proxy/router/v3;routerv3";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+option (xds.annotations.v3.file_status).work_in_progress = true;
+
+// [#protodoc-title: Router for generic proxy]
+// [#extension: envoy.filters.generic.router]
+
+message Router {
+  // Set to true if the upstream connection should be bound to the downstream connection, false
+  // otherwise.
+  //
+  // By default, one random upstream connection will be selected from the upstream connection pool
+  // and used for every request. And after the request is finished, the upstream connection will be
+  // released back to the upstream connection pool.
+  //
+  // If this option is true, the upstream connection will be bound to the downstream connection and
+  // have same lifetime as the downstream connection. The same upstream connection will be used for
+  // all requests from the same downstream connection.
+  //
+  // And if this options is true, one of the following requirements must be met:
+  //
+  // 1. The request must be handled one by one. That is, the next request can not be sent to the
+  //    upstream until the previous request is finished.
+  // 2. Unique request id must be provided for each request and response. The request id must be
+  //    unique for each request and response pair in same connection pair. And the request id must
+  //    be the same for the corresponding request and response.
+  //
+  // This could be useful for some protocols that require the same upstream connection to be used
+  // for all requests from the same downstream connection. For example, the protocol using stateful
+  // connection.
+  bool bind_upstream_connection = 1;
+}

--- a/src/main/proto/contrib/envoy/extensions/filters/network/generic_proxy/v3/generic_proxy.proto
+++ b/src/main/proto/contrib/envoy/extensions/filters/network/generic_proxy/v3/generic_proxy.proto
@@ -1,0 +1,67 @@
+syntax = "proto3";
+
+package envoy.extensions.filters.network.generic_proxy.v3;
+
+import "contrib/envoy/extensions/filters/network/generic_proxy/v3/route.proto";
+import "envoy/config/accesslog/v3/accesslog.proto";
+import "envoy/config/core/v3/config_source.proto";
+import "envoy/config/core/v3/extension.proto";
+import "envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto";
+
+import "xds/annotations/v3/status.proto";
+
+import "udpa/annotations/status.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.filters.network.generic_proxy.v3";
+option java_outer_classname = "GenericProxyProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/network/generic_proxy/v3;generic_proxyv3";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+option (xds.annotations.v3.file_status).work_in_progress = true;
+
+// [#protodoc-title: Generic Proxy]
+// Generic proxy.
+// [#extension: envoy.filters.network.generic_proxy]
+
+// [#next-free-field: 8]
+message GenericProxy {
+  // The human readable prefix to use when emitting statistics.
+  string stat_prefix = 1 [(validate.rules).string = {min_len: 1}];
+
+  // The codec which encodes and decodes the application protocol.
+  // [#extension-category: envoy.generic_proxy.codecs]
+  config.core.v3.TypedExtensionConfig codec_config = 2
+      [(validate.rules).message = {required: true}];
+
+  oneof route_specifier {
+    option (validate.required) = true;
+
+    // The generic proxies route table will be dynamically loaded via the meta RDS API.
+    GenericRds generic_rds = 3;
+
+    // The route table for the generic proxy is static and is specified in this property.
+    RouteConfiguration route_config = 4;
+  }
+
+  // A list of individual Layer-7 filters that make up the filter chain for requests made to the
+  // proxy. Order matters as the filters are processed sequentially as request events
+  // happen.
+  // [#extension-category: envoy.generic_proxy.filters]
+  repeated config.core.v3.TypedExtensionConfig filters = 5;
+
+  // Tracing configuration for the generic proxy.
+  http_connection_manager.v3.HttpConnectionManager.Tracing tracing = 6;
+
+  // Configuration for :ref:`access logs <arch_overview_access_logs>` emitted by generic proxy.
+  repeated config.accesslog.v3.AccessLog access_log = 7;
+}
+
+message GenericRds {
+  // Configuration source specifier for RDS.
+  config.core.v3.ConfigSource config_source = 1 [(validate.rules).message = {required: true}];
+
+  // The name of the route configuration. This name will be passed to the RDS API. This allows an
+  // Envoy configuration with multiple generic proxies to use different route configurations.
+  string route_config_name = 2 [(validate.rules).string = {min_len: 1}];
+}

--- a/src/main/proto/contrib/envoy/extensions/filters/network/generic_proxy/v3/route.proto
+++ b/src/main/proto/contrib/envoy/extensions/filters/network/generic_proxy/v3/route.proto
@@ -1,0 +1,105 @@
+syntax = "proto3";
+
+package envoy.extensions.filters.network.generic_proxy.v3;
+
+import "xds/annotations/v3/status.proto";
+import "xds/type/matcher/v3/matcher.proto";
+
+import "udpa/annotations/status.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.filters.network.generic_proxy.v3";
+option java_outer_classname = "RouteProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/network/generic_proxy/v3;generic_proxyv3";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+option (xds.annotations.v3.file_status).work_in_progress = true;
+
+// [#protodoc-title: Generic Proxy Route Configuration]
+
+message VirtualHost {
+  // The name of the virtual host.
+  string name = 1 [(validate.rules).string = {min_len: 1}];
+
+  // A list of hosts that will be matched to this virtual host. Wildcard hosts are supported in
+  // the suffix or prefix form.
+  //
+  // Host search order:
+  //  1. Exact names: ``www.foo.com``.
+  //  2. Suffix wildcards: ``*.foo.com`` or ``*-bar.foo.com``.
+  //  3. Prefix wildcards: ``foo.*`` or ``foo-*``.
+  //  4. Special wildcard ``*`` matching any host and will be the default virtual host.
+  //
+  // .. note::
+  //
+  //   The wildcard will not match the empty string.
+  //   e.g. ``*-bar.foo.com`` will match ``baz-bar.foo.com`` but not ``-bar.foo.com``.
+  //   The longest wildcards match first.
+  //   Only a single virtual host in the entire route configuration can match on ``*``. A domain
+  //   must be unique across all virtual hosts or the config will fail to load.
+  repeated string hosts = 2 [(validate.rules).repeated = {min_items: 1}];
+
+  // The match tree to use when resolving route actions for incoming requests.
+  xds.type.matcher.v3.Matcher routes = 3 [(validate.rules).message = {required: true}];
+}
+
+// The generic proxy makes use of the xDS matching API for routing configurations.
+//
+// In the below example, we combine a top level tree matcher with a linear matcher to match
+// the incoming requests, and send the matching requests to v1 of the upstream service.
+//
+// .. code-block:: yaml
+//
+//   name: example
+//   routes:
+//     matcher_tree:
+//       input:
+//         name: request-service
+//         typed_config:
+//           "@type": type.googleapis.com/envoy.extensions.filters.network.generic_proxy.matcher.v3.ServiceMatchInput
+//       exact_match_map:
+//         map:
+//           service_name_0:
+//             matcher:
+//               matcher_list:
+//                 matchers:
+//                 - predicate:
+//                     and_matcher:
+//                       predicate:
+//                       - single_predicate:
+//                           input:
+//                             name: request-properties
+//                             typed_config:
+//                               "@type": type.googleapis.com/envoy.extensions.filters.network.generic_proxy.matcher.v3.PropertyMatchInput
+//                               property_name: version
+//                           value_match:
+//                             exact: v1
+//                       - single_predicate:
+//                           input:
+//                             name: request-properties
+//                             typed_config:
+//                               "@type": type.googleapis.com/envoy.extensions.filters.network.generic_proxy.matcher.v3.PropertyMatchInput
+//                               property_name: user
+//                           value_match:
+//                             exact: john
+//                   on_match:
+//                     action:
+//                       name: route
+//                       typed_config:
+//                         "@type": type.googleapis.com/envoy.extensions.filters.network.generic_proxy.action.v3.routeAction
+//                         cluster: cluster_0
+message RouteConfiguration {
+  // The name of the route configuration. For example, it might match route_config_name in
+  // envoy.extensions.filters.network.generic_proxy.v3.Rds.
+  string name = 1 [(validate.rules).string = {min_len: 1}];
+
+  // The match tree to use when resolving route actions for incoming requests.
+  // If no any virtual host is configured in the ``virtual_hosts`` field or no special wildcard
+  // virtual host is configured, the ``routes`` field will be used as the default route table.
+  // If both the wildcard virtual host and ``routes`` are configured, the configuration will fail
+  // to load.
+  xds.type.matcher.v3.Matcher routes = 2;
+
+  // An array of virtual hosts that make up the route table.
+  repeated VirtualHost virtual_hosts = 3;
+}

--- a/src/main/proto/contrib/envoy/extensions/filters/network/golang/v3alpha/golang.proto
+++ b/src/main/proto/contrib/envoy/extensions/filters/network/golang/v3alpha/golang.proto
@@ -1,0 +1,54 @@
+syntax = "proto3";
+
+package envoy.extensions.filters.network.golang.v3alpha;
+
+import "google/protobuf/any.proto";
+
+import "xds/annotations/v3/status.proto";
+
+import "udpa/annotations/status.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.filters.network.golang.v3alpha";
+option java_outer_classname = "GolangProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/network/golang/v3alpha";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+option (xds.annotations.v3.file_status).work_in_progress = true;
+
+// [#protodoc-title: Golang network filter]
+//
+// Golang network filter :ref:`configuration overview <config_network_filters_golang>`.
+// [#extension: envoy.filters.network.golang]
+
+// [#next-free-field: 6]
+message Config {
+  // Bool ``true`` if this filter must be the last filter in a filter chain, ``false`` otherwise.
+  bool is_terminal_filter = 1;
+
+  // Globally unique ID for a dynamic library file.
+  string library_id = 2 [(validate.rules).string = {min_len: 1}];
+
+  // Path to a dynamic library implementing the
+  // :repo:`DownstreamFilter API <contrib/golang/common/go/api.DownstreamFilter>`
+  // interface.
+  // [#comment:TODO(wangfakang): Support for downloading libraries from remote repositories.]
+  string library_path = 3 [(validate.rules).string = {min_len: 1}];
+
+  // Globally unique name of the Go plugin.
+  //
+  // This name **must** be consistent with the name registered in ``network::RegisterNetworkFilterConfigFactory``
+  //
+  string plugin_name = 4 [(validate.rules).string = {min_len: 1}];
+
+  // Configuration for the Go plugin.
+  //
+  // .. note::
+  //     This configuration is only parsed in the go plugin, and is therefore not validated
+  //     by Envoy.
+  //
+  //     See the :repo:`DownstreamFilter API <contrib/golang/common/go/api/filter.go>`
+  //     for more information about how the plugin's configuration data can be accessed.
+  //
+  google.protobuf.Any plugin_config = 5;
+}

--- a/src/main/proto/contrib/envoy/extensions/filters/network/kafka_broker/v3/kafka_broker.proto
+++ b/src/main/proto/contrib/envoy/extensions/filters/network/kafka_broker/v3/kafka_broker.proto
@@ -1,0 +1,63 @@
+syntax = "proto3";
+
+package envoy.extensions.filters.network.kafka_broker.v3;
+
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.filters.network.kafka_broker.v3";
+option java_outer_classname = "KafkaBrokerProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/network/kafka_broker/v3;kafka_brokerv3";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: Kafka Broker]
+// Kafka Broker :ref:`configuration overview <config_network_filters_kafka_broker>`.
+// [#extension: envoy.filters.network.kafka_broker]
+
+message KafkaBroker {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.config.filter.network.kafka_broker.v2alpha1.KafkaBroker";
+
+  // The prefix to use when emitting :ref:`statistics <config_network_filters_kafka_broker_stats>`.
+  string stat_prefix = 1 [(validate.rules).string = {min_len: 1}];
+
+  // Set to true if broker filter should attempt to serialize the received responses from the
+  // upstream broker instead of passing received bytes as is.
+  // Disabled by default.
+  bool force_response_rewrite = 2;
+
+  // Optional broker address rewrite specification.
+  // Allows the broker filter to rewrite Kafka responses so that all connections established by
+  // the Kafka clients point to Envoy.
+  // This allows Kafka cluster not to configure its 'advertised.listeners' property
+  // (as the necessary re-pointing will be done by this filter).
+  // This collection of rules should cover all brokers in the cluster that is being proxied,
+  // otherwise some nodes' addresses might leak to the downstream clients.
+  oneof broker_address_rewrite_spec {
+    // Broker address rewrite rules that match by broker ID.
+    IdBasedBrokerRewriteSpec id_based_broker_address_rewrite_spec = 3;
+  }
+}
+
+// Collection of rules matching by broker ID.
+message IdBasedBrokerRewriteSpec {
+  repeated IdBasedBrokerRewriteRule rules = 1;
+}
+
+// Defines a rule to rewrite broker address data.
+message IdBasedBrokerRewriteRule {
+  // Broker ID to match.
+  uint32 id = 1 [(validate.rules).uint32 = {gte: 0}];
+
+  // The host value to use (resembling the host part of Kafka's advertised.listeners).
+  // The value should point to the Envoy (not Kafka) listener, so that all client traffic goes
+  // through Envoy.
+  string host = 2 [(validate.rules).string = {min_len: 1}];
+
+  // The port value to use (resembling the port part of Kafka's advertised.listeners).
+  // The value should point to the Envoy (not Kafka) listener, so that all client traffic goes
+  // through Envoy.
+  uint32 port = 3 [(validate.rules).uint32 = {lte: 65535}];
+}

--- a/src/main/proto/contrib/envoy/extensions/filters/network/kafka_mesh/v3alpha/kafka_mesh.proto
+++ b/src/main/proto/contrib/envoy/extensions/filters/network/kafka_mesh/v3alpha/kafka_mesh.proto
@@ -1,0 +1,79 @@
+syntax = "proto3";
+
+package envoy.extensions.filters.network.kafka_mesh.v3alpha;
+
+import "xds/annotations/v3/status.proto";
+
+import "udpa/annotations/status.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.filters.network.kafka_mesh.v3alpha";
+option java_outer_classname = "KafkaMeshProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/network/kafka_mesh/v3alpha";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+option (xds.annotations.v3.file_status).work_in_progress = true;
+
+// [#protodoc-title: Kafka Mesh]
+// Kafka Mesh :ref:`configuration overview <config_network_filters_kafka_mesh>`.
+// [#extension: envoy.filters.network.kafka_mesh]
+
+// [#next-free-field: 6]
+message KafkaMesh {
+  enum ConsumerProxyMode {
+    // Records received are going to be distributed amongst downstream consumer connections.
+    // In this mode Envoy uses librdkafka consumers pointing at upstream Kafka clusters, what means that these
+    // consumers' position is meaningful and affects what records are received from upstream.
+    // Users might want to take a look into these consumers' custom configuration to manage their auto-committing
+    // capabilities, as it will impact Envoy's behaviour in case of restarts.
+    StatefulConsumerProxy = 0;
+  }
+
+  // Envoy's host that's advertised to clients.
+  // Has the same meaning as corresponding Kafka broker properties.
+  // Usually equal to filter chain's listener config, but needs to be reachable by clients
+  // (so 0.0.0.0 will not work).
+  string advertised_host = 1 [(validate.rules).string = {min_len: 1}];
+
+  // Envoy's port that's advertised to clients.
+  int32 advertised_port = 2 [(validate.rules).int32 = {gt: 0}];
+
+  // Upstream clusters this filter will connect to.
+  repeated KafkaClusterDefinition upstream_clusters = 3;
+
+  // Rules that will decide which cluster gets which request.
+  repeated ForwardingRule forwarding_rules = 4;
+
+  // How the consumer proxying should behave - this relates mostly to Fetch request handling.
+  ConsumerProxyMode consumer_proxy_mode = 5;
+}
+
+// [#next-free-field: 6]
+message KafkaClusterDefinition {
+  // Cluster name.
+  string cluster_name = 1 [(validate.rules).string = {min_len: 1}];
+
+  // Kafka cluster address.
+  string bootstrap_servers = 2 [(validate.rules).string = {min_len: 1}];
+
+  // Default number of partitions present in this cluster.
+  // This is especially important for clients that do not specify partition in their payloads and depend on this value for hashing.
+  // The same number of partitions is going to be used by upstream-pointing Kafka consumers for consumer proxying scenarios.
+  int32 partition_count = 3 [(validate.rules).int32 = {gt: 0}];
+
+  // Custom configuration passed to Kafka producer.
+  map<string, string> producer_config = 4;
+
+  // Custom configuration passed to Kafka consumer.
+  map<string, string> consumer_config = 5;
+}
+
+message ForwardingRule {
+  // Cluster name.
+  string target_cluster = 1;
+
+  oneof trigger {
+    // Intended place for future types of forwarding rules.
+    string topic_prefix = 2;
+  }
+}

--- a/src/main/proto/contrib/envoy/extensions/filters/network/mysql_proxy/v3/mysql_proxy.proto
+++ b/src/main/proto/contrib/envoy/extensions/filters/network/mysql_proxy/v3/mysql_proxy.proto
@@ -1,0 +1,30 @@
+syntax = "proto3";
+
+package envoy.extensions.filters.network.mysql_proxy.v3;
+
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.filters.network.mysql_proxy.v3";
+option java_outer_classname = "MysqlProxyProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/network/mysql_proxy/v3;mysql_proxyv3";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: MySQL proxy]
+// MySQL Proxy :ref:`configuration overview <config_network_filters_mysql_proxy>`.
+// [#extension: envoy.filters.network.mysql_proxy]
+
+message MySQLProxy {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.config.filter.network.mysql_proxy.v1alpha1.MySQLProxy";
+
+  // The human readable prefix to use when emitting :ref:`statistics
+  // <config_network_filters_mysql_proxy_stats>`.
+  string stat_prefix = 1 [(validate.rules).string = {min_len: 1}];
+
+  // [#not-implemented-hide:] The optional path to use for writing MySQL access logs.
+  // If the access log field is empty, access logs will not be written.
+  string access_log = 2;
+}

--- a/src/main/proto/contrib/envoy/extensions/filters/network/postgres_proxy/v3alpha/postgres_proxy.proto
+++ b/src/main/proto/contrib/envoy/extensions/filters/network/postgres_proxy/v3alpha/postgres_proxy.proto
@@ -1,0 +1,62 @@
+syntax = "proto3";
+
+package envoy.extensions.filters.network.postgres_proxy.v3alpha;
+
+import "google/protobuf/wrappers.proto";
+
+import "udpa/annotations/status.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.filters.network.postgres_proxy.v3alpha";
+option java_outer_classname = "PostgresProxyProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/network/postgres_proxy/v3alpha";
+option (udpa.annotations.file_status).work_in_progress = true;
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: Postgres proxy]
+// Postgres Proxy :ref:`configuration overview
+// <config_network_filters_postgres_proxy>`.
+// [#extension: envoy.filters.network.postgres_proxy]
+
+message PostgresProxy {
+  // Upstream SSL operational modes.
+  enum SSLMode {
+    // Do not encrypt upstream connection to the server.
+    DISABLE = 0;
+
+    // Establish upstream SSL connection to the server. If the server does not
+    // accept the request for SSL connection, the session is terminated.
+    REQUIRE = 1;
+  }
+
+  // The human readable prefix to use when emitting :ref:`statistics
+  // <config_network_filters_postgres_proxy_stats>`.
+  string stat_prefix = 1 [(validate.rules).string = {min_len: 1}];
+
+  // Controls whether SQL statements received in Frontend Query messages
+  // are parsed. Parsing is required to produce Postgres proxy filter
+  // metadata. Defaults to true.
+  google.protobuf.BoolValue enable_sql_parsing = 2;
+
+  // Controls whether to terminate SSL session initiated by a client.
+  // If the value is false, the Postgres proxy filter will not try to
+  // terminate SSL session, but will pass all the packets to the upstream server.
+  // If the value is true, the Postgres proxy filter will try to terminate SSL
+  // session. In order to do that, the filter chain must use :ref:`starttls transport socket
+  // <envoy_v3_api_msg_extensions.transport_sockets.starttls.v3.StartTlsConfig>`.
+  // If the filter does not manage to terminate the SSL session, it will close the connection from the client.
+  // Refer to official documentation for details
+  // `SSL Session Encryption Message Flow <https://www.postgresql.org/docs/current/protocol-flow.html#id-1.10.5.7.11>`_.
+  bool terminate_ssl = 3;
+
+  // Controls whether to establish upstream SSL connection to the server.
+  // Envoy will try to establish upstream SSL connection to the server only when
+  // Postgres filter is able to read Postgres payload in clear-text. It happens when
+  // a client established a clear-text connection to Envoy or when a client established
+  // SSL connection to Envoy and Postgres filter is configured to terminate SSL.
+  // In order for upstream encryption to work, the corresponding cluster must be configured to use
+  // :ref:`starttls transport socket <envoy_v3_api_msg_extensions.transport_sockets.starttls.v3.UpstreamStartTlsConfig>`.
+  // Defaults to ``SSL_DISABLE``.
+  SSLMode upstream_ssl = 4;
+}

--- a/src/main/proto/contrib/envoy/extensions/filters/network/rocketmq_proxy/v3/rocketmq_proxy.proto
+++ b/src/main/proto/contrib/envoy/extensions/filters/network/rocketmq_proxy/v3/rocketmq_proxy.proto
@@ -1,0 +1,35 @@
+syntax = "proto3";
+
+package envoy.extensions.filters.network.rocketmq_proxy.v3;
+
+import "contrib/envoy/extensions/filters/network/rocketmq_proxy/v3/route.proto";
+
+import "google/protobuf/duration.proto";
+
+import "udpa/annotations/status.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.filters.network.rocketmq_proxy.v3";
+option java_outer_classname = "RocketmqProxyProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/network/rocketmq_proxy/v3;rocketmq_proxyv3";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: RocketMQ Proxy]
+// RocketMQ Proxy :ref:`configuration overview <config_network_filters_rocketmq_proxy>`.
+// [#extension: envoy.filters.network.rocketmq_proxy]
+
+message RocketmqProxy {
+  // The human readable prefix to use when emitting statistics.
+  string stat_prefix = 1 [(validate.rules).string = {min_len: 1}];
+
+  // The route table for the connection manager is specified in this property.
+  RouteConfiguration route_config = 2;
+
+  // The largest duration transient object expected to live, more than 10s is recommended.
+  google.protobuf.Duration transient_object_life_span = 3;
+
+  // If develop_mode is enabled, this proxy plugin may work without dedicated traffic intercepting
+  // facility without considering backward compatibility of exiting RocketMQ client SDK.
+  bool develop_mode = 4;
+}

--- a/src/main/proto/contrib/envoy/extensions/filters/network/rocketmq_proxy/v3/route.proto
+++ b/src/main/proto/contrib/envoy/extensions/filters/network/rocketmq_proxy/v3/route.proto
@@ -1,0 +1,55 @@
+syntax = "proto3";
+
+package envoy.extensions.filters.network.rocketmq_proxy.v3;
+
+import "envoy/config/core/v3/base.proto";
+import "envoy/config/route/v3/route_components.proto";
+import "envoy/type/matcher/v3/string.proto";
+
+import "udpa/annotations/status.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.filters.network.rocketmq_proxy.v3";
+option java_outer_classname = "RouteProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/network/rocketmq_proxy/v3;rocketmq_proxyv3";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: Rocketmq Proxy Route Configuration]
+// Rocketmq Proxy :ref:`configuration overview <config_network_filters_rocketmq_proxy>`.
+
+message RouteConfiguration {
+  // The name of the route configuration.
+  string name = 1;
+
+  // The list of routes that will be matched, in order, against incoming requests. The first route
+  // that matches will be used.
+  repeated Route routes = 2;
+}
+
+message Route {
+  // Route matching parameters.
+  RouteMatch match = 1 [(validate.rules).message = {required: true}];
+
+  // Route request to some upstream cluster.
+  RouteAction route = 2 [(validate.rules).message = {required: true}];
+}
+
+message RouteMatch {
+  // The name of the topic.
+  type.matcher.v3.StringMatcher topic = 1 [(validate.rules).message = {required: true}];
+
+  // Specifies a set of headers that the route should match on. The router will check the request’s
+  // headers against all the specified headers in the route config. A match will happen if all the
+  // headers in the route are present in the request with the same values (or based on presence if
+  // the value field is not in the config).
+  repeated config.route.v3.HeaderMatcher headers = 2;
+}
+
+message RouteAction {
+  // Indicates the upstream cluster to which the request should be routed.
+  string cluster = 1 [(validate.rules).string = {min_len: 1}];
+
+  // Optional endpoint metadata match criteria used by the subset load balancer.
+  config.core.v3.Metadata metadata_match = 2;
+}

--- a/src/main/proto/contrib/envoy/extensions/filters/network/sip_proxy/router/v3alpha/router.proto
+++ b/src/main/proto/contrib/envoy/extensions/filters/network/sip_proxy/router/v3alpha/router.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package envoy.extensions.filters.network.sip_proxy.router.v3alpha;
+
+import "udpa/annotations/status.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.filters.network.sip_proxy.router.v3alpha";
+option java_outer_classname = "RouterProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/network/sip_proxy/router/v3alpha";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: Router]
+// [#extension: envoy.filters.sip.router]
+
+message Router {
+}

--- a/src/main/proto/contrib/envoy/extensions/filters/network/sip_proxy/tra/v3alpha/tra.proto
+++ b/src/main/proto/contrib/envoy/extensions/filters/network/sip_proxy/tra/v3alpha/tra.proto
@@ -1,0 +1,132 @@
+syntax = "proto3";
+
+package envoy.extensions.filters.network.sip_proxy.tra.v3alpha;
+
+import "envoy/config/core/v3/config_source.proto";
+import "envoy/config/core/v3/grpc_service.proto";
+
+import "google/protobuf/duration.proto";
+
+import "udpa/annotations/status.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.filters.network.sip_proxy.tra.v3alpha";
+option java_outer_classname = "TraProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/network/sip_proxy/tra/v3alpha";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: TRA]
+
+service TraService {
+  rpc Create(TraServiceRequest) returns (TraServiceResponse) {
+  }
+
+  rpc Update(TraServiceRequest) returns (TraServiceResponse) {
+  }
+
+  rpc Retrieve(TraServiceRequest) returns (TraServiceResponse) {
+  }
+
+  rpc Delete(TraServiceRequest) returns (TraServiceResponse) {
+  }
+
+  rpc Subscribe(TraServiceRequest) returns (stream TraServiceResponse) {
+  }
+}
+
+message TraServiceConfig {
+  // Specifies the gRPC service that hosts the rate limit service. The client
+  // will connect to this cluster when it needs to make rate limit service
+  // requests.
+  config.core.v3.GrpcService grpc_service = 1 [(validate.rules).message = {required: true}];
+
+  // API version for rate limit transport protocol. This describes the rate limit gRPC endpoint and
+  // version of messages used on the wire.
+  config.core.v3.ApiVersion transport_api_version = 2
+      [(validate.rules).enum = {defined_only: true}];
+
+  google.protobuf.Duration timeout = 3;
+}
+
+// [#next-free-field: 7]
+message TraServiceRequest {
+  string type = 1;
+
+  oneof request {
+    CreateRequest create_request = 2;
+
+    UpdateRequest update_request = 3;
+
+    RetrieveRequest retrieve_request = 4;
+
+    DeleteRequest delete_request = 5;
+
+    SubscribeRequest subscribe_request = 6;
+  }
+}
+
+// [#next-free-field: 9]
+message TraServiceResponse {
+  string type = 1;
+
+  int32 ret = 2;
+
+  string reason = 3;
+
+  oneof response {
+    CreateResponse create_response = 4;
+
+    UpdateResponse update_response = 5;
+
+    RetrieveResponse retrieve_response = 6;
+
+    DeleteResponse delete_response = 7;
+
+    SubscribeResponse subscribe_response = 8;
+  }
+}
+
+message CreateRequest {
+  map<string, string> data = 1;
+
+  map<string, string> context = 2;
+}
+
+message CreateResponse {
+}
+
+message UpdateRequest {
+  map<string, string> data = 1;
+
+  map<string, string> context = 2;
+}
+
+message UpdateResponse {
+}
+
+message RetrieveRequest {
+  string key = 1;
+
+  map<string, string> context = 2;
+}
+
+message RetrieveResponse {
+  map<string, string> data = 1;
+}
+
+message DeleteRequest {
+  string key = 1;
+
+  map<string, string> context = 2;
+}
+
+message DeleteResponse {
+}
+
+message SubscribeRequest {
+}
+
+message SubscribeResponse {
+  map<string, string> data = 1;
+}

--- a/src/main/proto/contrib/envoy/extensions/filters/network/sip_proxy/v3alpha/route.proto
+++ b/src/main/proto/contrib/envoy/extensions/filters/network/sip_proxy/v3alpha/route.proto
@@ -1,0 +1,56 @@
+syntax = "proto3";
+
+package envoy.extensions.filters.network.sip_proxy.v3alpha;
+
+import "udpa/annotations/status.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.filters.network.sip_proxy.v3alpha";
+option java_outer_classname = "RouteProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/network/sip_proxy/v3alpha";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: Sip Proxy Route Configuration]
+
+message RouteConfiguration {
+  // The name of the route configuration. Reserved for future use in asynchronous route discovery.
+  string name = 1;
+
+  // The list of routes that will be matched, in order, against incoming requests. The first route
+  // that matches will be used.
+  repeated Route routes = 2;
+}
+
+message Route {
+  // Route matching parameters.
+  RouteMatch match = 1 [(validate.rules).message = {required: true}];
+
+  // Route request to some upstream cluster.
+  RouteAction route = 2 [(validate.rules).message = {required: true}];
+}
+
+message RouteMatch {
+  oneof match_specifier {
+    option (validate.required) = true;
+
+    // The domain from Request URI or Route Header.
+    string domain = 1;
+  }
+
+  // The header to get match parameter, default is "Route".
+  string header = 2;
+
+  // The parameter to get domain, default is "host".
+  string parameter = 3;
+}
+
+message RouteAction {
+  oneof cluster_specifier {
+    option (validate.required) = true;
+
+    // Indicates a single upstream cluster to which the request should be routed
+    // to.
+    string cluster = 1 [(validate.rules).string = {min_len: 1}];
+  }
+}

--- a/src/main/proto/contrib/envoy/extensions/filters/network/sip_proxy/v3alpha/sip_proxy.proto
+++ b/src/main/proto/contrib/envoy/extensions/filters/network/sip_proxy/v3alpha/sip_proxy.proto
@@ -1,0 +1,161 @@
+syntax = "proto3";
+
+package envoy.extensions.filters.network.sip_proxy.v3alpha;
+
+import "contrib/envoy/extensions/filters/network/sip_proxy/tra/v3alpha/tra.proto";
+import "contrib/envoy/extensions/filters/network/sip_proxy/v3alpha/route.proto";
+
+import "google/protobuf/any.proto";
+import "google/protobuf/duration.proto";
+
+import "udpa/annotations/status.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.filters.network.sip_proxy.v3alpha";
+option java_outer_classname = "SipProxyProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/network/sip_proxy/v3alpha";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: Sip Proxy]
+// [#extension: envoy.filters.network.sip_proxy]
+
+message SipProxy {
+  message SipSettings {
+    // transaction timeout timer [Timer B] unit is milliseconds, default value 64*T1.
+    //
+    // Session Initiation Protocol (SIP) timer summary
+    //
+    // +---------+-------------------------+----------+------------------------------------------------------------------------------+
+    // | Timer   | Default value           | Section  | Meaning                                                                      |
+    // +=========+=========================+==========+==============================================================================+
+    // | T1      | 500 ms                  | 17.1.1.1 | Round-trip time (RTT) estimate                                               |
+    // +---------+-------------------------+----------+------------------------------------------------------------------------------+
+    // | T2      | 4 sec                   | 17.1.2.2 | Maximum re-transmission interval for non-INVITE requests and INVITE responses|
+    // +---------+-------------------------+----------+------------------------------------------------------------------------------+
+    // | T4      | 5 sec                   | 17.1.2.2 | Maximum duration that a message can remain in the network                    |
+    // +---------+-------------------------+----------+------------------------------------------------------------------------------+
+    // | Timer A | initially T1            | 17.1.1.2 | INVITE request re-transmission interval, for UDP only                        |
+    // +---------+-------------------------+----------+------------------------------------------------------------------------------+
+    // | Timer B | 64*T1                   | 17.1.1.2 | INVITE transaction timeout timer                                             |
+    // +---------+-------------------------+----------+------------------------------------------------------------------------------+
+    // | Timer D | > 32 sec. for UDP       | 17.1.1.2 | Wait time for response re-transmissions                                      |
+    // |         | 0 sec. for TCP and SCTP |          |                                                                              |
+    // +---------+-------------------------+----------+------------------------------------------------------------------------------+
+    // | Timer E | initially T1            | 17.1.2.2 | Non-INVITE request re-transmission interval, UDP only                        |
+    // +---------+-------------------------+----------+------------------------------------------------------------------------------+
+    // | Timer F | 64*T1                   | 17.1.2.2 | Non-INVITE transaction timeout timer                                         |
+    // +---------+-------------------------+----------+------------------------------------------------------------------------------+
+    // | Timer G | initially T1            | 17.2.1   | INVITE response re-transmission interval                                     |
+    // +---------+-------------------------+----------+------------------------------------------------------------------------------+
+    // | Timer H | 64*T1                   | 17.2.1   | Wait time for ACK receipt                                                    |
+    // +---------+-------------------------+----------+------------------------------------------------------------------------------+
+    // | Timer I | T4 for UDP              | 17.2.1   | Wait time for ACK re-transmissions                                           |
+    // |         | 0 sec. for TCP and SCTP |          |                                                                              |
+    // +---------+-------------------------+----------+------------------------------------------------------------------------------+
+    // | Timer J | 64*T1 for UDP           | 17.2.2   | Wait time for re-transmissions of non-INVITE requests                        |
+    // |         | 0 sec. for TCP and SCTP |          |                                                                              |
+    // +---------+-------------------------+----------+------------------------------------------------------------------------------+
+    // | Timer K | T4 for UDP              | 17.1.2.2 | Wait time for response re-transmissions                                      |
+    // |         | 0 sec. for TCP and SCTP |          |                                                                              |
+    // +---------+-------------------------+----------+------------------------------------------------------------------------------+
+    google.protobuf.Duration transaction_timeout = 1;
+
+    // The service to match for ep insert
+    repeated LocalService local_services = 2;
+
+    tra.v3alpha.TraServiceConfig tra_service_config = 3;
+
+    // Whether via header is operated, including add via for request and pop via for response
+    // False: sip service proxy
+    // True:  sip load balancer
+    bool operate_via = 4;
+  }
+
+  // The human readable prefix to use when emitting statistics.
+  string stat_prefix = 1 [(validate.rules).string = {min_len: 1}];
+
+  // The route table for the connection manager is static and is specified in this property.
+  RouteConfiguration route_config = 2;
+
+  // A list of individual Sip filters that make up the filter chain for requests made to the
+  // Sip proxy. Order matters as the filters are processed sequentially. For backwards
+  // compatibility, if no sip_filters are specified, a default Sip router filter
+  // (``envoy.filters.sip.router``) is used.
+  // [#extension-category: envoy.sip_proxy.filters]
+  repeated SipFilter sip_filters = 3;
+
+  SipSettings settings = 4;
+}
+
+// SipFilter configures a Sip filter.
+message SipFilter {
+  // The name of the filter to instantiate. The name must match a supported
+  // filter. The built-in filters are:
+  //
+  string name = 1 [(validate.rules).string = {min_len: 1}];
+
+  // Filter specific configuration which depends on the filter being instantiated. See the supported
+  // filters for further documentation.
+  oneof config_type {
+    google.protobuf.Any typed_config = 3;
+  }
+}
+
+// SipProtocolOptions specifies Sip upstream protocol options. This object is used in
+// :ref:`typed_extension_protocol_options<envoy_v3_api_field_config.cluster.v3.Cluster.typed_extension_protocol_options>`,
+// keyed by the name ``envoy.filters.network.sip_proxy``.
+message SipProtocolOptions {
+  // All sip messages in one dialog should go to the same endpoint.
+  bool session_affinity = 1;
+
+  // The Register with Authorization header should go to the same endpoint which send out the 401 Unauthorized.
+  bool registration_affinity = 2;
+
+  // Customized affinity
+  CustomizedAffinity customized_affinity = 3;
+}
+
+// For affinity
+message CustomizedAffinity {
+  // Affinity rules to conclude the upstream endpoint
+  repeated CustomizedAffinityEntry entries = 1;
+
+  // Configures whether load balance should be stopped or continued after affinity handling.
+  bool stop_load_balance = 2;
+}
+
+// [#next-free-field: 6]
+message CustomizedAffinityEntry {
+  // The header name to match, e.g. "From", if not specified, default is "Route"
+  string header = 1;
+
+  // Affinity key for TRA query/subscribe, e.g. "lskpmc", if key_name is "text" means use the header content as key.
+  string key_name = 2;
+
+  // Whether subscribe to TRA is required
+  bool subscribe = 3;
+
+  // Whether query to TRA is required
+  bool query = 4;
+
+  // Local cache
+  Cache cache = 5;
+}
+
+message Cache {
+  // Affinity local cache item max number
+  int32 max_cache_item = 1;
+
+  // Whether query result can be added to local cache
+  bool add_query_to_cache = 2;
+}
+
+// Local Service
+message LocalService {
+  // The domain need to matched
+  string domain = 1;
+
+  // The parameter to get domain
+  string parameter = 2;
+}

--- a/src/main/proto/contrib/envoy/extensions/matching/input_matchers/hyperscan/v3alpha/hyperscan.proto
+++ b/src/main/proto/contrib/envoy/extensions/matching/input_matchers/hyperscan/v3alpha/hyperscan.proto
@@ -1,0 +1,79 @@
+syntax = "proto3";
+
+package envoy.extensions.matching.input_matchers.hyperscan.v3alpha;
+
+import "udpa/annotations/status.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.matching.input_matchers.hyperscan.v3alpha";
+option java_outer_classname = "HyperscanProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/matching/input_matchers/hyperscan/v3alpha";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: Hyperscan matcher]
+// Hyperscan :ref:`configuration overview <config_hyperscan>`.
+// [#extension: envoy.matching.input_matchers.hyperscan]
+
+// `Hyperscan <https://github.com/intel/hyperscan>`_ regex matcher. The matcher uses the Hyperscan
+// engine which exploits x86 SIMD instructions to accelerate matching large numbers of regular
+// expressions simultaneously across streams of data.
+message Hyperscan {
+  // [#next-free-field: 11]
+  message Regex {
+    // The regex expression.
+    //
+    // The expression must represent only the pattern to be matched, with no delimiters or flags.
+    string regex = 1 [(validate.rules).string = {min_len: 1}];
+
+    // The ID of the regex expression.
+    //
+    // This option is designed to be used on the sub-expressions in logical combinations.
+    uint32 id = 2;
+
+    // Matching will be performed case-insensitively.
+    //
+    // The expression may still use PCRE tokens (notably ``(?i)`` and ``(?-i)``) to switch
+    // case-insensitive matching on and off.
+    bool caseless = 3;
+
+    // Matching a ``.`` will not exclude newlines.
+    bool dot_all = 4;
+
+    // ``^`` and ``$`` anchors match any newlines in data.
+    bool multiline = 5;
+
+    // Allow expressions which can match against an empty string.
+    //
+    // This option instructs the compiler to allow expressions that can match against empty buffers,
+    // such as ``.?``, ``.*``, ``(a|)``. Since Hyperscan can return every possible match for an expression,
+    // such expressions generally execute very slowly.
+    bool allow_empty = 6;
+
+    // Treat the pattern as a sequence of UTF-8 characters.
+    bool utf8 = 7;
+
+    // Use Unicode properties for character classes.
+    //
+    // This option instructs Hyperscan to use Unicode properties, rather than the default ASCII
+    // interpretations, for character mnemonics like ``\w`` and ``\s`` as well as the POSIX character
+    // classes. It is only meaningful in conjunction with ``utf8``.
+    bool ucp = 8;
+
+    // Logical combination.
+    //
+    // This option instructs Hyperscan to parse this expression as logical combination syntax.
+    // Logical constraints consist of operands, operators and parentheses. The operands are
+    // expression indices, and operators can be ``!``, ``&`` or ``|``.
+    bool combination = 9;
+
+    // Don’t do any match reporting.
+    //
+    // This option instructs Hyperscan to ignore match reporting for this expression. It is
+    // designed to be used on the sub-expressions in logical combinations.
+    bool quiet = 10;
+  }
+
+  // Specifies a set of regex expressions that the input should match on.
+  repeated Regex regexes = 1 [(validate.rules).repeated = {min_items: 1}];
+}

--- a/src/main/proto/contrib/envoy/extensions/network/connection_balance/dlb/v3alpha/dlb.proto
+++ b/src/main/proto/contrib/envoy/extensions/network/connection_balance/dlb/v3alpha/dlb.proto
@@ -1,0 +1,52 @@
+syntax = "proto3";
+
+package envoy.extensions.network.connection_balance.dlb.v3alpha;
+
+import "udpa/annotations/status.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.network.connection_balance.dlb.v3alpha";
+option java_outer_classname = "DlbProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/network/connection_balance/dlb/v3alpha";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: Dlb connection balancer configuration]
+// DLB :ref:`configuration overview <config_connection_balance_dlb>`.
+// [#extension: envoy.network.connection_balance.dlb]
+
+// The Dlb is a hardware managed system of queues and arbiters connecting producers and consumers. It is a PCIE device
+// in the CPU package. It interacts with software running on cores and potentially other devices. The Dlb implements the
+// following balancing features:
+//
+// -  Lock-free multi-producer/multi-consumer operation.
+// -  Multiple priorities for varying traffic types.
+// -  Various distribution schemes.
+//
+// Dlb connection balancer uses Dlb hardware to balance connections, and can significantly reduce latency.
+//
+// As the Dlb connection balancer provides assistance from dedicated Dlb hardware, it can be used for a proxy with a large number of connections
+// (e.g., a gateway).
+message Dlb {
+  // The fallback policy if any error occurs.
+  // The default policy is None.
+  enum FallbackPolicy {
+    // No fallback policy.
+    None = 0;
+
+    // Fall back to Nop Connection Balance.
+    NopConnectionBalance = 1;
+
+    // Fall back to Exact Connection Balance.
+    ExactConnectionBalance = 2;
+  }
+
+  // The ID of the Dlb hardware, start from 0.
+  // If not specified, use the first available device as default.
+  uint32 id = 1;
+
+  // Maximum number of retries when sending to DLB device fails.
+  // No retry as default.
+  uint32 max_retries = 2;
+
+  FallbackPolicy fallback_policy = 3;
+}

--- a/src/main/proto/contrib/envoy/extensions/private_key_providers/cryptomb/v3alpha/cryptomb.proto
+++ b/src/main/proto/contrib/envoy/extensions/private_key_providers/cryptomb/v3alpha/cryptomb.proto
@@ -1,0 +1,45 @@
+syntax = "proto3";
+
+package envoy.extensions.private_key_providers.cryptomb.v3alpha;
+
+import "envoy/config/core/v3/base.proto";
+
+import "google/protobuf/duration.proto";
+
+import "udpa/annotations/sensitive.proto";
+import "udpa/annotations/status.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.private_key_providers.cryptomb.v3alpha";
+option java_outer_classname = "CryptombProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/private_key_providers/cryptomb/v3alpha";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: CryptoMb private key provider]
+// [#extension: envoy.tls.key_providers.cryptomb]
+
+// A CryptoMbPrivateKeyMethodConfig message specifies how the CryptoMb private
+// key provider is configured. The private key provider provides ``SIMD``
+// processing for RSA sign and decrypt operations (ECDSA signing uses regular
+// BoringSSL functions). The provider works by gathering the operations into a
+// worker-thread specific queue, and processing the queue using ``ipp-crypto``
+// library when the queue is full or when a timer expires.
+// [#extension-category: envoy.tls.key_providers]
+message CryptoMbPrivateKeyMethodConfig {
+  // Private key to use in the private key provider. If set to inline_bytes or
+  // inline_string, the value needs to be the private key in PEM format.
+  config.core.v3.DataSource private_key = 1 [(udpa.annotations.sensitive) = true];
+
+  // How long to wait until the per-thread processing queue should be
+  // processed. If the processing queue gets full (eight sign or decrypt
+  // requests are received) it is processed immediately. However, if the
+  // queue is not filled before the delay has expired, the requests
+  // already in the queue are processed, even if the queue is not full.
+  // In effect, this value controls the balance between latency and
+  // throughput. The duration needs to be set to a value greater than or equal to 1 millisecond.
+  google.protobuf.Duration poll_delay = 2 [(validate.rules).duration = {
+    required: true
+    gte {nanos: 1000000}
+  }];
+}

--- a/src/main/proto/contrib/envoy/extensions/private_key_providers/qat/v3alpha/qat.proto
+++ b/src/main/proto/contrib/envoy/extensions/private_key_providers/qat/v3alpha/qat.proto
@@ -1,0 +1,40 @@
+syntax = "proto3";
+
+package envoy.extensions.private_key_providers.qat.v3alpha;
+
+import "envoy/config/core/v3/base.proto";
+
+import "google/protobuf/duration.proto";
+
+import "udpa/annotations/sensitive.proto";
+import "udpa/annotations/status.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.private_key_providers.qat.v3alpha";
+option java_outer_classname = "QatProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/private_key_providers/qat/v3alpha";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: `QAT` private key provider]
+// [#extension: envoy.tls.key_providers.qat]
+
+// This message specifies how the private key provider is configured.
+// The private key provider provides RSA sign and decrypt operation
+// hardware acceleration.
+
+message QatPrivateKeyMethodConfig {
+  // Private key to use in the private key provider. If set to inline_bytes or
+  // inline_string, the value needs to be the private key in PEM format.
+  config.core.v3.DataSource private_key = 1 [(udpa.annotations.sensitive) = true];
+
+  // How long to wait before polling the hardware accelerator after a
+  // request has been submitted there. Having a small value leads to
+  // quicker answers from the hardware but causes more polling loop
+  // spins, leading to potentially larger CPU usage. The duration needs
+  // to be set to a value greater than or equal to 1 millisecond.
+  google.protobuf.Duration poll_delay = 2 [(validate.rules).duration = {
+    required: true
+    gte {nanos: 1000000}
+  }];
+}

--- a/src/main/proto/contrib/envoy/extensions/regex_engines/hyperscan/v3alpha/hyperscan.proto
+++ b/src/main/proto/contrib/envoy/extensions/regex_engines/hyperscan/v3alpha/hyperscan.proto
@@ -1,0 +1,26 @@
+syntax = "proto3";
+
+package envoy.extensions.regex_engines.hyperscan.v3alpha;
+
+import "udpa/annotations/status.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.regex_engines.hyperscan.v3alpha";
+option java_outer_classname = "HyperscanProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/regex_engines/hyperscan/v3alpha";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: Hyperscan]
+// Hyperscan :ref:`configuration overview <config_hyperscan>`.
+// [#extension: envoy.regex_engines.hyperscan]
+
+// `Hyperscan <https://github.com/intel/hyperscan>`_ regex engine. The engine uses hybrid automata
+// techniques to allow simultaneous matching of large numbers of regular expressions across streams
+// of data.
+//
+// The engine follows PCRE pattern syntax, and the regex string must adhere to the documented
+// `pattern support <https://intel.github.io/hyperscan/dev-reference/compilation.html#pattern-support>`_.
+// The syntax is not compatible with the default RE2 regex engine. Depending on configured
+// expressions, swapping regex engine may cause match rules to no longer be valid.
+message Hyperscan {
+}

--- a/src/main/proto/contrib/envoy/extensions/router/cluster_specifier/golang/v3alpha/golang.proto
+++ b/src/main/proto/contrib/envoy/extensions/router/cluster_specifier/golang/v3alpha/golang.proto
@@ -1,0 +1,51 @@
+syntax = "proto3";
+
+package envoy.extensions.router.cluster_specifier.golang.v3alpha;
+
+import "google/protobuf/any.proto";
+
+import "xds/annotations/v3/status.proto";
+
+import "udpa/annotations/status.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.router.cluster_specifier.golang.v3alpha";
+option java_outer_classname = "GolangProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/router/cluster_specifier/golang/v3alpha";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+option (xds.annotations.v3.file_status).work_in_progress = true;
+
+// [#protodoc-title: Golang]
+//
+// For an overview of the Golang cluster specifier please see the :ref:`configuration reference documentation <config_http_cluster_specifier_golang>`.
+// [#extension: envoy.router.cluster_specifier_plugin.golang]
+
+// [#extension-category: envoy.router.cluster_specifier_plugin]
+message Config {
+  // Globally unique ID for a dynamic library file.
+  string library_id = 1 [(validate.rules).string = {min_len: 1}];
+
+  // Path to a dynamic library implementing the
+  // :repo:`ClusterSpecifier API <contrib/golang/router/cluster_specifier/source/go/pkg/api.ClusterSpecifier>`
+  // interface.
+  // [#comment:TODO(wangfakang): Support for downloading libraries from remote repositories.]
+  string library_path = 2 [(validate.rules).string = {min_len: 1}];
+
+  // Default cluster.
+  //
+  // It will be used when the specifier interface return empty string or panic.
+  //
+  string default_cluster = 3 [(validate.rules).string = {min_len: 1}];
+
+  // Configuration for the Go cluster specifier plugin.
+  //
+  // .. note::
+  //     This configuration is only parsed in the go cluster specifier, and is therefore not validated
+  //     by Envoy.
+  //
+  //     See the :repo:`StreamFilter API <contrib/golang/router/cluster_specifier/source/go/pkg/cluster_specifier/config.go>`
+  //     for more information about how the plugin's configuration data can be accessed.
+  //
+  google.protobuf.Any config = 4;
+}

--- a/src/main/proto/contrib/envoy/extensions/vcl/v3alpha/vcl_socket_interface.proto
+++ b/src/main/proto/contrib/envoy/extensions/vcl/v3alpha/vcl_socket_interface.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+package envoy.extensions.vcl.v3alpha;
+
+import "udpa/annotations/status.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.vcl.v3alpha";
+option java_outer_classname = "VclSocketInterfaceProto";
+option java_multiple_files = true;
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/vcl/v3alpha";
+option (udpa.annotations.file_status).work_in_progress = true;
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: VCL socket interface configuration]
+// VCL :ref:`configuration overview <config_sock_interface_vcl>`.
+// [#extension: envoy.bootstrap.vcl]
+
+// Configuration for vcl socket interface that relies on ``vpp`` ``comms`` library (VCL)
+message VclSocketInterface {
+}

--- a/tools/update-api.sh
+++ b/tools/update-api.sh
@@ -29,11 +29,13 @@ pushd "${tmpdir}" >/dev/null
 
 rm -rf "${protodir}"
 
-curl -sL https://github.com/envoyproxy/envoy/archive/${ENVOY_SHA}.tar.gz | tar xz --wildcards '*.proto'
+curl -sL https://github.com/envoyproxy/envoy/archive/${ENVOY_SHA}.tar.gz | tar xz --include '*.proto'
 mkdir -p "${protodir}/envoy"
 cp -r envoy-*/api/envoy/* "${protodir}/envoy"
+mkdir -p "${protodir}/contrib"
+cp -r envoy-*/api/contrib/* "${protodir}/contrib"
 
-curl -sL https://github.com/googleapis/googleapis/archive/${GOOGLEAPIS_SHA}.tar.gz | tar xz --wildcards '*.proto'
+curl -sL https://github.com/googleapis/googleapis/archive/${GOOGLEAPIS_SHA}.tar.gz | tar xz --include '*.proto'
 mkdir -p "${protodir}/google/api"
 mkdir -p "${protodir}/google/api/expr/v1alpha1"
 mkdir -p "${protodir}/google/rpc"
@@ -43,25 +45,25 @@ cp googleapis-*/google/api/expr/v1alpha1/checked.proto "${protodir}/google/api/e
 cp googleapis-*/google/rpc/status.proto "${protodir}/google/rpc"
 
 # Note: uses v... from 1.19
-curl -sL https://github.com/envoyproxy/protoc-gen-validate/archive/v${PGV_VERSION}.tar.gz | tar xz --wildcards '*.proto'
+curl -sL https://github.com/envoyproxy/protoc-gen-validate/archive/v${PGV_VERSION}.tar.gz | tar xz --include '*.proto'
 mkdir -p "${protodir}/validate"
 cp -r protoc-gen-validate-*/validate/* "${protodir}/validate"
 
-curl -sL https://github.com/census-instrumentation/opencensus-proto/archive/v${OPENCENSUS_VERSION}.tar.gz | tar xz --wildcards '*.proto'
+curl -sL https://github.com/census-instrumentation/opencensus-proto/archive/v${OPENCENSUS_VERSION}.tar.gz | tar xz --include '*.proto'
 mkdir -p "${protodir}/opencensus/proto"
 cp -r opencensus-proto-*/src/opencensus/proto/* "${protodir}/opencensus/proto"
 
-curl -sL https://github.com/prometheus/client_model/archive/v${PROMETHEUS_VERSION}.tar.gz | tar xz --wildcards '*.proto'
+curl -sL https://github.com/prometheus/client_model/archive/v${PROMETHEUS_VERSION}.tar.gz | tar xz --include '*.proto'
 mkdir -p "${protodir}/io/prometheus/client/"
 cp client_model-*/io/prometheus/client/metrics.proto "${protodir}/io/prometheus/client/"
 
-curl -sL https://github.com/cncf/xds/archive/${XDS_SHA}.tar.gz | tar xz --wildcards '*.proto'
+curl -sL https://github.com/cncf/xds/archive/${XDS_SHA}.tar.gz | tar xz --include '*.proto'
 mkdir -p "${protodir}/udpa"
 mkdir -p "${protodir}/xds"
 cp -r xds-*/udpa/* "${protodir}/udpa"
 cp -r xds-*/xds/* "${protodir}/xds"
 
-curl -sL https://github.com/open-telemetry/opentelemetry-proto/archive/v${OPENTELEMETRY_VERSION}.tar.gz | tar xz --wildcards '*.proto'
+curl -sL https://github.com/open-telemetry/opentelemetry-proto/archive/v${OPENTELEMETRY_VERSION}.tar.gz | tar xz --include '*.proto'
 mkdir -p "${protodir}/opentelemetry/proto"
 cp -r opentelemetry-proto-*/opentelemetry/proto/* "${protodir}/opentelemetry/proto"
 


### PR DESCRIPTION
## Context

I want to make use of the [kafka broker filter](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/kafka_broker/v3/kafka_broker.proto#envoy-v3-api-msg-extensions-filters-network-kafka-broker-v3-kafkabroker), however this is included in the contrib package not the main one (meaning we don't copy the files over).

## Checklist
- [X] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
