### PR TITLE
[CONNECT-2858] Bump protobuf library and grpc version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,11 +44,12 @@ tasks.withType(Javadoc).configureEach {
     options.addStringOption('Xdoclint:none', '-quiet')
 }
 
-def grpcVersion = '1.54.1'
-def protobufVersion = '3.21.12'
+def grpcVersion = '1.62.2'
+def protobufVersion = '3.25.6'
 def protocVersion = protobufVersion
 
 dependencies {
+    implementation "com.google.protobuf:protobuf-java:${protobufVersion}"
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"
     implementation "io.grpc:grpc-stub:${grpcVersion}"
     implementation 'javax.annotation:javax.annotation-api:1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -44,8 +44,8 @@ tasks.withType(Javadoc).configureEach {
     options.addStringOption('Xdoclint:none', '-quiet')
 }
 
-def grpcVersion = '1.62.2'
-def protobufVersion = '3.25.6'
+def grpcVersion = '1.79.0'
+def protobufVersion = '3.25.9'
 def protocVersion = protobufVersion
 
 dependencies {


### PR DESCRIPTION
## Context

Protobuf dependency is outdated and it cases a bunch of warnings in the logs. 

## Checklist
- [X] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
