### PR TITLE
[CONNECT-2858] Update build script to fail with a clear error if a tag exists already

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,8 @@ jobs:
         run: apt-get update && apt-get install -y git
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-tags: true
       - name: "Validate version tag doesn't exist"
         run: |
           VERSION=$(grep '^version=' gradle.properties | cut -d'=' -f2)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,8 @@ jobs:
         run: |
           VERSION=$(grep '^version=' gradle.properties | cut -d'=' -f2)
           TAG="v${VERSION}"
-          if git ls-remote --tags origin | grep -q "refs/tags/${TAG}$"; then
+          REPO_URL="https://github.com/${{ github.repository }}"
+          if git ls-remote --tags "${REPO_URL}" | grep -q "refs/tags/${TAG}$"; then
             echo "============================================="
             echo "ERROR: Tag ${TAG} already exists!"
             echo ""

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,19 +25,7 @@ jobs:
         with:
           fetch-tags: true
       - name: "Validate version tag doesn't exist"
-        run: |
-          VERSION=$(grep '^version=' gradle.properties | cut -d'=' -f2)
-          TAG="v${VERSION}"
-          REPO_URL="https://github.com/${{ github.repository }}"
-          if git ls-remote --tags "${REPO_URL}" | grep -q "refs/tags/${TAG}$"; then
-            echo "============================================="
-            echo "ERROR: Tag ${TAG} already exists!"
-            echo ""
-            echo "Please bump the version in gradle.properties"
-            echo "============================================="
-            exit 1
-          fi
-          echo "✓ Version ${VERSION} is valid (tag ${TAG} does not exist yet)"
+        run: GRADLE_USER_HOME=$HOME/.gradle ./gradlew validateVersion --console=plain --no-daemon
       - name: "Gradle cache"
         uses: actions/cache@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,8 +22,6 @@ jobs:
         run: apt-get update && apt-get install -y git
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-tags: true
       - name: "Validate version tag doesn't exist"
         run: GRADLE_USER_HOME=$HOME/.gradle ./gradlew validateVersion --console=plain --no-daemon
       - name: "Gradle cache"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,19 @@ jobs:
         run: apt-get update && apt-get install -y git
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: "Validate version tag doesn't exist"
+        run: |
+          VERSION=$(grep '^version=' gradle.properties | cut -d'=' -f2)
+          TAG="v${VERSION}"
+          if git ls-remote --tags origin | grep -q "refs/tags/${TAG}$"; then
+            echo "============================================="
+            echo "ERROR: Tag ${TAG} already exists!"
+            echo ""
+            echo "Please bump the version in gradle.properties"
+            echo "============================================="
+            exit 1
+          fi
+          echo "✓ Version ${VERSION} is valid (tag ${TAG} does not exist yet)"
       - name: "Gradle cache"
         uses: actions/cache@v4
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -164,7 +164,7 @@ task tagRelease {
             grgit.push(refsOrSpecs: ["v$version"])
         }
         catch (RefAlreadyExistsException ignored) {
-            logger.warn("Tag v$version already exists.")
+            throw new GradleException("Tag v$version already exists. Bump the version in gradle.properties before tagging again.")
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -44,11 +44,12 @@ tasks.withType(Javadoc).configureEach {
     options.addStringOption('Xdoclint:none', '-quiet')
 }
 
-def grpcVersion = '1.54.1'
-def protobufVersion = '3.21.12'
+def grpcVersion = '1.62.2'
+def protobufVersion = '3.25.6'
 def protocVersion = protobufVersion
 
 dependencies {
+    implementation "com.google.protobuf:protobuf-java:${protobufVersion}"
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"
     implementation "io.grpc:grpc-stub:${grpcVersion}"
     implementation 'javax.annotation:javax.annotation-api:1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -172,16 +172,13 @@ task tagRelease {
 task validateVersion {
     doLast {
         def tagName = "v$version"
-        def remoteTags = grgit.lsremote(tags: true).keySet().collect { it.toString() }
-        def remoteHasTag = remoteTags.any { it.endsWith("/${tagName}") || it == tagName }
+        def remoteTags = grgit.lsremote(tags: true)
+
+        def refName = "refs/tags/${tagName}"
+        def remoteHasTag = remoteTags.keySet().any { ref -> ref.fullName == refName }
+
         if (remoteHasTag) {
-            throw new GradleException("""
-                |=============================================
-                | ERROR: Tag ${tagName} already exists!
-                |
-                | Please bump the version in gradle.properties
-                |=============================================
-            """.stripMargin())
+            throw new GradleException("Tag ${tagName} already exists. Bump the version in gradle.properties.")
         }
         logger.lifecycle("✓ Version ${version} is valid (tag ${tagName} does not exist yet)")
     }

--- a/build.gradle
+++ b/build.gradle
@@ -168,3 +168,21 @@ task tagRelease {
         }
     }
 }
+
+task validateVersion {
+    doLast {
+        def tagName = "v$version"
+        def remoteTags = grgit.lsremote(tags: true).keySet().collect { it.toString() }
+        def remoteHasTag = remoteTags.any { it.endsWith("/${tagName}") || it == tagName }
+        if (remoteHasTag) {
+            throw new GradleException("""
+                |=============================================
+                | ERROR: Tag ${tagName} already exists!
+                |
+                | Please bump the version in gradle.properties
+                |=============================================
+            """.stripMargin())
+        }
+        logger.lifecycle("✓ Version ${version} is valid (tag ${tagName} does not exist yet)")
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -164,7 +164,7 @@ task tagRelease {
             grgit.push(refsOrSpecs: ["v$version"])
         }
         catch (RefAlreadyExistsException ignored) {
-            throw new GradleException("Tag v$version already exists. Bump the version in gradle.properties before tagging again.")
+            logger.warn("Tag v$version already exists.")
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -44,8 +44,8 @@ tasks.withType(Javadoc).configureEach {
     options.addStringOption('Xdoclint:none', '-quiet')
 }
 
-def grpcVersion = '1.62.2'
-def protobufVersion = '3.25.6'
+def grpcVersion = '1.79.0'
+def protobufVersion = '3.25.9'
 def protocVersion = protobufVersion
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.35.8-2
+version=1.35.8-1
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.35.8-1
+version=1.35.8-2
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8


### PR DESCRIPTION
## Context

We have a releaseTag job which is running on main only and fails if a tag already exists on origin. Let's introduce a separate validation step and notify a user if a tag needs bumping. 

<img width="1049" height="188" alt="image" src="https://github.com/user-attachments/assets/3f2746ae-8292-49bc-842d-978489371a03" />



## Checklist
- [X] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
